### PR TITLE
Solve numpy numba version conflict 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         'bmi-python',
         'netCDF4',
         'scipy',
-        'numpy',
+        'numpy<1.24',
         'matplotlib',
         'numba'
     ],

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         'docopt==0.6.1',
         'bmi-python',
         'netCDF4',
-        'scipy<1.10',
+        'scipy',
         'numpy<1.24,>=1.18',
         'matplotlib',
         'numba'

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         'bmi-python',
         'netCDF4',
         'scipy',
-        'numpy<1.24',
+        'numpy<1.24,>=1.18',
         'matplotlib',
         'numba'
     ],

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         'docopt==0.6.1',
         'bmi-python',
         'netCDF4',
-        'scipy',
+        'scipy<1.10',
         'numpy<1.24,>=1.18',
         'matplotlib',
         'numba'


### PR DESCRIPTION
Fixes #76  

### Description of the changes
A maximum version of 1.24 and a minimum of 1.18 is specified for numpy in setup.py.

### What impact does the changes have?
The changes resolve the version conflict between numpy and numba and the aeolis command line interface runs successfully.

### How the changes have been tested?
- Running `aeolis` from the root of the repository no longer gives the error reported in #76.  
- The example `aeolis examples/1D/case1_small_waves/aeolis.txt` is run successfully. 