### PR TITLE
Patch/deprications

### DIFF
--- a/aeolis/model.py
+++ b/aeolis/model.py
@@ -28,7 +28,8 @@ The Netherlands                  The Netherlands
 from __future__ import absolute_import, division
 
 import os
-import imp
+# import imp
+import importlib
 import time
 import glob
 import logging
@@ -63,6 +64,7 @@ from typing import Any, Union, Tuple
 from numpy import ndarray
 
 from aeolis.utils import *
+
 
 class StreamFormatter(logging.Formatter):
     """A formater for log messages"""

--- a/aeolis/model.py
+++ b/aeolis/model.py
@@ -28,8 +28,7 @@ The Netherlands                  The Netherlands
 from __future__ import absolute_import, division
 
 import os
-# import imp
-import importlib
+import importlib.machinery
 import time
 import glob
 import logging
@@ -2909,7 +2908,7 @@ class AeoLiSRunner(AeoLiS):
             if ':' in callback:
                 fname, func = callback.split(':')
                 if os.path.exists(fname):
-                    mod = imp.load_source('callback', fname)
+                    mod = importlib.machinery.SourceFileLoader('callback', fname).load_module()
                     if hasattr(mod, func):
                         return getattr(mod, func)
         elif hasattr(callback, '__call__'):

--- a/aeolis/tests/integration_tests/test_netCDF_file_creation.py
+++ b/aeolis/tests/integration_tests/test_netCDF_file_creation.py
@@ -1,5 +1,4 @@
 import os
-import numpy as np
 import pytest
 
 from aeolis import model


### PR DESCRIPTION
The `imp` built-in package is deprecated. Therefore, this PR substitute it for the `importlib`, as recommended by the Python documentation.

Pytest reports other warnings, including the use of `matrix()` instead of the recomended `ndarray`. However, this is an issue in the **numpy** source code and not of AeoLiS