### PR TITLE
change spelling of package name to lowercase

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,14 @@ effects, air humidity and roughness elements.
 
 - Python 3.8 or newer 
 - pip 22.0 or newer
+- netCDF4
 
 ### Installing from PyPI
 
 On the comand line of your working environment (Bash/Shell, Conda, Mamba, or similar), run the following: 
 
 ```shell
-pip install AeoLiS
+pip install aeolis
 ```
 
 > For Windows users, the recommend way to install AeoLiS is to use [Anaconda](https://docs.anaconda.com/free/anaconda/install/windows/).
@@ -51,10 +52,11 @@ pip install AeoLiS
 
 ### Running AeoLiS
 
-Example from command line:
+Examples from command line:
 
 ```shell
 aeolis params.txt
+# or wind module
 aeolis-wind wind.txt --mean=6 --duration=3600
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 [![Codecov](https://codecov.io/gh/openearth/aeolis-python/branch/master/graph/badge.svg)](https://codecov.io/gh/openearth/aeolis-python)
 [![ReadTheDocs](http://readthedocs.org/projects/aeolis/badge/?version=latest)](http://aeolis.readthedocs.io/en/latest/)
-[![PyPI](https://img.shields.io/pypi/v/AeoLiS.svg)](https://pypi.python.org/pypi/AeoLiS)
-[![PyPI_versions](https://img.shields.io/pypi/pyversions/AeoLiS.svg)](https://pypi.python.org/pypi/AeoLiS)
-[![PyPI_status](https://img.shields.io/pypi/status/AeoLiS.svg)](https://pypi.python.org/pypi/AeoLiS)
-[![PyPI_format](https://img.shields.io/pypi/format/AeoLiS.svg)](https://pypi.python.org/pypi/AeoLiS)
-[![License](https://img.shields.io/pypi/l/AeoLiS.svg)](https://pypi.python.org/pypi/AeoLiS)
+[![PyPI](https://img.shields.io/pypi/v/aeolis.svg)](https://pypi.python.org/pypi/aeolis)
+[![PyPI_versions](https://img.shields.io/pypi/pyversions/aeolis.svg)](https://pypi.python.org/pypi/aeolis)
+[![PyPI_status](https://img.shields.io/pypi/status/aeolis.svg)](https://pypi.python.org/pypi/aeolis)
+[![PyPI_format](https://img.shields.io/pypi/format/aeolis.svg)](https://pypi.python.org/pypi/aeolis)
+[![License](https://img.shields.io/pypi/l/aeolis.svg)](https://pypi.python.org/pypi/aeolis)
 [![DOI](https://zenodo.org/badge/7830/openearth/aeolis-python.svg)](https://zenodo.org/badge/latestdoi/7830/openearth/aeolis-python)
 
 # AeoLiS

--- a/docs/defaults.rst
+++ b/docs/defaults.rst
@@ -1,3 +1,6 @@
+
+.. _default settings:
+
 Default settings
 ================
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -8,9 +8,9 @@ AeoLiS is a Python package that can be installed from PyPI or from source. For t
 Requirements
 ------------
 
-- Python 3.8 or higher 
-- Setuptools
-- pip 
+- Python 3.8 or newer 
+- pip 22.0 or newer
+- netCDF4
 
 Installing from PyPI
 ---------------------
@@ -19,9 +19,9 @@ On the comand line of your working environment (Bash/Shell, Conda, Mamba, or sim
 
 .. code:: shell
 
-   pip install AeoLiS
+   pip install aeolis
 
-.. note::
+.. attention:: 
 
    For Windows users, the recommend way to install AeoLiS is to use `Anaconda <https://docs.anaconda.com/free/anaconda/install/windows/>`_.
 
@@ -49,4 +49,7 @@ Example from command line:
 .. code:: shell
 
    aeolis params.txt
-   aeolis-wind wind.txt --mean=6 --duration=3600
+
+.. note::
+
+   Model parameters and other configuration is passed in a `params.txt`. See the :ref:`default settings` for more details.  

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 sphinxcontrib-bibtex>=2.5.0
-AeoLiS
+aeolis
 sphinx-copybutton==0.5.2
 plot==0.6.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ exclude = [
 ]
 
 [project]
-name = "AeoLiS"
+name = "aeolis"
 version = "2.1.1"
 authors = [
   { name="Sierd de Vries", email="sierd.devries@tudelft.nl" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ exclude = [
 
 [project]
 name = "aeolis"
-version = "2.1.1"
+version = "2.1.2"
 authors = [
   { name="Sierd de Vries", email="sierd.devries@tudelft.nl" },
 ]


### PR DESCRIPTION
- Changes the name of the package to lowercase, this complies with the Python conventions, and shall fix the problem with case-sensitive OSs (Windows). Fixes #140 

- [x] Check issue `package not found` is fixed in Windows