### PR TITLE
Indent deprecation text by one blank line to improve readability

### DIFF
--- a/aeolis/console.py
+++ b/aeolis/console.py
@@ -160,9 +160,9 @@ def print_license():
 def start_aeolis_app():
     if len(sys.argv) == 2 and os.path.isfile(sys.argv[1]):
         print(
-            "Usage of the command line syntax `aeolis <path_to_aeolis.txt>` has"
-            " been deprecated from v3.0.0 onwards.\n\n"
-            "To run a model, use the syntax `aeolis run <path_to_aeolis.txt>`\n"
+            "\nUsage of the command line syntax `aeolis <path_to_aeolis.txt>`"
+            " has been deprecated from v3.0.0 onwards.\n\nTo run a model, use"
+            " the syntax `aeolis run <path_to_aeolis.txt>`\n"
         )
         sys.exit(1)
     else:
@@ -174,9 +174,9 @@ def start_aeolis_wind_app():
     This function serves the purpose of catching the deprecated command line syntx `aeolis-wind <path_to_wind.txt>` and pritning a message on the console instructing the user to use `aeolis wind <path_to_wind.txt>` instead.
     """
     print(
-        "Usage of the command line syntax `aeolis-wind <path_to_wind.txt>` has"
-        " been deprecated from v3.0.0 onwards.\n\nTo run the wind module, use"
-        " the syntax `aeolis wind <path_to_wind.txt>`\n"
+        "\nUsage of the command line syntax `aeolis-wind <path_to_wind.txt>`"
+        " has been deprecated from v3.0.0 onwards.\n\nTo run the wind module,"
+        " use the syntax `aeolis wind <path_to_wind.txt>`\n"
     )
     sys.exit(1)
 


### PR DESCRIPTION
Before indentation

```
$ aeolis aeolis/examples/1D/case1_small_waves/aeolis.txt
Usage of the command line syntax `aeolis <path_to_aeolis.txt>` has been deprecated from v3.0.0 onwards.

To run a model, use the syntax `aeolis run <path_to_aeolis.txt>`

$
```
After indentation

```
$ aeolis aeolis/examples/1D/case1_small_waves/aeolis.txt

Usage of the command line syntax `aeolis <path_to_aeolis.txt>` has been deprecated from v3.0.0 onwards.

To run a model, use the syntax `aeolis run <path_to_aeolis.txt>`

$
```