### PR TITLE
max_moist implementation

### DIFF
--- a/aeolis/constants.py
+++ b/aeolis/constants.py
@@ -292,6 +292,7 @@ DEFAULT_CONFIG = {
     'in_gw'                         : 0,                  # [m] Initial groundwater level
     'GW_stat'                       : 1,                  # [m] Landward static groundwater boundary (if static boundary is defined)
     'max_moist'                     : 10.,           # NEWCH      # [%] Moisture content (volumetric in percent) above which the threshold shear velocity is set to infinity (no transport, default value Delgado-Fernandez, 2010)
+    'max_moist'                     : 10.,                # [%] Moisture content (volumetric in percent) above which the threshold shear velocity is set to infinity (no transport, default value Delgado-Fernandez, 2010)
     'theta_dyn'                     : 33.,                # [degrees] Initial Dynamic angle of repose, critical dynamic slope for avalanching
     'theta_stat'                    : 34.,                # [degrees] Initial Static angle of repose, critical static slope for avalanching
     'avg_time'                      : 86400.,             # [s] Indication of the time period over which the bed level change is averaged for vegetation growth

--- a/aeolis/constants.py
+++ b/aeolis/constants.py
@@ -291,6 +291,7 @@ DEFAULT_CONFIG = {
     'Cl_gw'                         : 0.7,                # [m] Groundwater overheight due to runup
     'in_gw'                         : 0,                  # [m] Initial groundwater level
     'GW_stat'                       : 1,                  # [m] Landward static groundwater boundary (if static boundary is defined)
+    'max_moist'                     : 10.,           # NEWCH      # [%] Moisture content (volumetric in percent) above which the threshold shear velocity is set to infinity (no transport, default value Delgado-Fernandez, 2010)
     'theta_dyn'                     : 33.,                # [degrees] Initial Dynamic angle of repose, critical dynamic slope for avalanching
     'theta_stat'                    : 34.,                # [degrees] Initial Static angle of repose, critical static slope for avalanching
     'avg_time'                      : 86400.,             # [s] Indication of the time period over which the bed level change is averaged for vegetation growth

--- a/aeolis/threshold.py
+++ b/aeolis/threshold.py
@@ -234,9 +234,11 @@ def compute_moisture(s, p):
     else:
         logger.log_and_raise('Unknown moisture formulation [%s]' % p['method_moist'], exc=ValueError)
 
+    th_mg = (p['max_moist']/100 * p['rhow'] / (p['rhog'] * (1. - p['porosity'])))
     # should be .04 according to Pye and Tsoar
-    # should be .64 according to Delgado-Fernandez (10% vol.)
-    ix = mg > 0.064
+    # should be .064 according to Delgado-Fernandez (10% vol.)
+    # .097 corresponds to 15%
+    ix = mg > th_mg
     s['uth'][ix] = np.inf
     
     return s


### PR DESCRIPTION
Implement user-defined value for the maximum moisture content at which transport can occur. This replaces the original implementation that had a hard coded value for the threshold (10% based on Delgado-Fernandez).